### PR TITLE
add process ID to temp file name to enable parallelised call of pdfbook

### DIFF
--- a/pdfbook2/pdfbook2
+++ b/pdfbook2/pdfbook2
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """ pdfbook2 - transform pdf files to booklets
-                   
+
     This program is free software: you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by
     the Free Software Foundation, either version 3 of the License, or
@@ -38,7 +38,7 @@ def booklify(name, opts):
 
     # ---------------------------------------------------------- useful constants
     bboxName = b"%%HiResBoundingBox:"
-    tmpFile = ".crop-tmp.pdf"
+    tmpFile = f".{os.getpid()}.crop-tmp.pdf"
 
     # ------------------------------------------------- find min/max bounding box
     if opts.crop:


### PR DESCRIPTION
When attempting to use pdfbook2 on multiple files simulataneously in a parallelised bash script, pdfbook2 throws a  `file not found` error in line `161` because each launched process uses the same file name for the temporary file. This is defined in line `41`: 
    ```41       tmpFile = ".crop-tmp.pdf"```
Adding the process ID to this temporary file fixes the issue. I suggest replacing line `41` by 
    ```41       tmpFile = f".{os.getpid()}.crop-tmp.pdf"```
In this way each of the temporary files is unique to each process. 